### PR TITLE
PLAT-143 Install sockets extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN sudo pecl install apcu geoip memcache memcached-2.2.0 redis
 RUN sudo docker-php-ext-enable geoip memcache memcached redis
 
 # Install PHP extensions
-RUN sudo docker-php-ext-install mcrypt opcache pdo_mysql soap tidy bcmath
+RUN sudo docker-php-ext-install mcrypt opcache pdo_mysql soap tidy bcmath sockets


### PR DESCRIPTION
This PR installs the `sockets` extension for use with Behat tests that attempt to interact with DataDog.