### PR TITLE
Try this one first.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image on CircleCI's image for PHP 5.6
-FROM circleci/php:5.6-apache-browsers
+FROM circleci/php:5.6-apache-jessie-browsers
 
 MAINTAINER Tim Rourke <trourke@activecampaign.com>
 


### PR DESCRIPTION
Circle has a long, long list of docker images: https://circleci.com/docs/2.0/docker-image-tags.json

We will try using the best-named, closest-to-what's-in-prod-now but still different image first.